### PR TITLE
Determine version information from version.json for newer Minecraft versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .VSCodeCounter
 
+msh
 msh.exe
 TODO

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -270,6 +270,14 @@ func (c *Configuration) extractVersionInfo() *errco.Error {
 		if c.Server.Protocol == 0 {
 			c.Server.Protocol = info.Protocol
 		}
+
+		// update and save default config
+		ConfigDefault.Server.Version = info.Version
+		ConfigDefault.Server.Protocol = info.Protocol
+		errMsh := ConfigDefault.Save()
+		if errMsh != nil {
+			return errMsh.AddTrace("extractVersionInfo")
+		}
 	}
 
 	// just log the error since version and protocol are not vital for connection to clients

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -88,21 +88,12 @@ func LoadConfig() *errco.Error {
 
 	errco.Logln(errco.LVL_D, "msh proxy setup: %s:%d --> %s:%d", ListenHost, ListenPort, TargetHost, TargetPort)
 
-	// set server and protocol version from server JAR file if not manually set in the config.
-	// required for backward-compatibility and for Minecraft versions without a version.info inside the JAR file
+	// set server and protocol version from server JAR file if not specified in config/arguments.
+	// required for backward-compatibility and for minecraft versions without a version.info inside the JAR file.
 	// (see https://minecraft.fandom.com/wiki/Version.json)
-	if ConfigRuntime.Server.Version == "" || ConfigRuntime.Server.Protocol == 0 {
-		var version, protocol, errMsh = getVersionInfo()
-		if errMsh != nil {
-			return errMsh.AddTrace("LoadConfig")
-		}
-
-		if ConfigRuntime.Server.Version == "" {
-			ConfigRuntime.Server.Version = version
-		}
-		if ConfigRuntime.Server.Protocol == 0 {
-			ConfigRuntime.Server.Protocol = protocol
-		}
+	errMsh = ConfigRuntime.extractVersionInfo()
+	if errMsh != nil {
+		return errMsh.AddTrace("LoadConfig")
 	}
 
 	// set server icon
@@ -236,40 +227,53 @@ func (c *Configuration) loadRuntime(base *Configuration) *errco.Error {
 	return nil
 }
 
-// getVersionInfo reads version.json from the server JAR file and returns the correct Minecraft version and protocol version
-func getVersionInfo() (string, int, *errco.Error) {
-	serverFileFolderPath := filepath.Join(ConfigRuntime.Server.Folder, ConfigRuntime.Server.FileName)
-	reader, err := zip.OpenReader(serverFileFolderPath)
+// extractVersionInfo reads version.json from the server JAR file
+// and sets the correct minecraft version and protocol in config
+func (c *Configuration) extractVersionInfo() *errco.Error {
+	if c.Server.Version != "" && c.Server.Protocol != 0 {
+		errco.LogMshErr(errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_D, "extractVersionInfo", "minecraft server version and protocol already specified"))
+		return nil
+	}
+
+	reader, err := zip.OpenReader(filepath.Join(c.Server.Folder, c.Server.FileName))
 	if err != nil {
-		return "", -1, errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_D, "getVersionInfo", err.Error())
+		return errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_D, "extractVersionInfo", err.Error())
 	}
 	defer reader.Close()
 
 	for _, file := range reader.File {
+		// search for version.json file
 		if file.Name != "version.json" {
 			continue
 		}
 
-		versionsReader, err := file.Open()
+		f, err := file.Open()
 		if err != nil {
-			return "", -1, errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_D, "getVersionInfo", err.Error())
+			return errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_D, "extractVersionInfo", err.Error())
 		}
-		defer versionsReader.Close()
+		defer f.Close()
 
-		versionsBytes, err := ioutil.ReadAll(versionsReader)
+		versionsBytes, err := ioutil.ReadAll(f)
 		if err != nil {
-			return "", -1, errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_D, "getVersionInfo", err.Error())
-		}
-
-		var result model.VersionInfo
-		err = json.Unmarshal(versionsBytes, &result)
-		if err != nil {
-			return "", -1, errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_D, "getVersionInfo", err.Error())
+			return errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_D, "extractVersionInfo", err.Error())
 		}
 
-		return result.Version, result.Protocol, nil
+		var info model.VersionInfo
+		err = json.Unmarshal(versionsBytes, &info)
+		if err != nil {
+			return errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_D, "extractVersionInfo", err.Error())
+		}
+
+		if c.Server.Version == "" {
+			c.Server.Version = info.Version
+		}
+		if c.Server.Protocol == 0 {
+			c.Server.Protocol = info.Protocol
+		}
 	}
 
-	return "", -1, errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_B, "getVersionInfo",
-		"version.json not found in server JAR file. Please manually specify Version and Protocol in the config under \"Server\"")
+	// just log the error since version and protocol are not vital for connection to clients
+	// (and might still be extracted while retrieving server info)
+	errco.LogMshErr(errco.NewErr(errco.ERROR_VERSION_LOAD, errco.LVL_D, "extractVersionInfo", "minecraft server version and protocol could not be extracted from version.json"))
+	return nil
 }

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -155,12 +155,11 @@ func (c *Configuration) loadDefault() *errco.Error {
 		}
 	}
 
-	// set server and protocol version from server JAR file if not specified in config/arguments.
-	// required for backward-compatibility and for minecraft versions without a version.json inside the JAR file.
-	// (see https://minecraft.fandom.com/wiki/Version.json)
+	// load ms version/protocol
+	// (checkout version.json info: https://minecraft.fandom.com/wiki/Version.json)
 	version, protocol, errMsh := c.getVersionInfo()
 	if errMsh != nil {
-		// just log error since ms server/protocol are not vital for the connection with clients
+		// just log error since ms version/protocol are not vital for the connection with clients
 		errco.LogMshErr(errMsh.AddTrace("loadDefault"))
 	} else if c.Server.Version != version || c.Server.Protocol != protocol {
 		c.Server.Version = version

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -30,9 +30,6 @@ var (
 
 	ServerIcon string // ServerIcon contains the minecraft server icon
 
-	Protocol int
-	Version  string
-
 	ListenHost string = "0.0.0.0"   // ListenHost is the ip address for clients to connect to msh
 	ListenPort int                  // ListenPort is the port for clients to connect to msh
 	TargetHost string = "127.0.0.1" // TargetHost is the ip address for msh to connect to minecraft server

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -150,8 +150,8 @@ func (c *Configuration) loadDefault() *errco.Error {
 		hasher := sha1.New()
 		hasher.Write([]byte(id + filepath.Dir(ex)))
 		clientID := hex.EncodeToString(hasher.Sum(nil))
-		c.Msh.ID = clientID
 		if c.Msh.ID != clientID {
+			c.Msh.ID = clientID
 			saveReq = true
 		}
 	}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -187,8 +187,8 @@ func (c *Configuration) loadRuntime(base *Configuration) *errco.Error {
 	// specify arguments
 	flag.StringVar(&c.Server.FileName, "file", c.Server.FileName, "Specify minecraft server file name.")
 	flag.StringVar(&c.Server.Folder, "folder", c.Server.Folder, "Specify minecraft server folder path.")
-	flag.StringVar(&c.Server.Version, "folder", c.Server.Version, "Specify minecraft server version.")
-	flag.IntVar(&c.Server.Protocol, "folder", c.Server.Protocol, "Specify minecraft server protocol.")
+	flag.StringVar(&c.Server.Version, "version", c.Server.Version, "Specify minecraft server version.")
+	flag.IntVar(&c.Server.Protocol, "protocol", c.Server.Protocol, "Specify minecraft server protocol.")
 
 	flag.StringVar(&ConfigRuntime.Commands.StartServerParam, "msparam", ConfigRuntime.Commands.StartServerParam, "Specify start server parameters.")
 	flag.IntVar(&ConfigRuntime.Commands.StopServerAllowKill, "allowKill", ConfigRuntime.Commands.StopServerAllowKill, "Specify after how many seconds the server should be killed (if stop command fails).")

--- a/lib/errco/errco-cod.go
+++ b/lib/errco/errco-cod.go
@@ -80,6 +80,7 @@ const (
 	ERROR_CONFIG_SAVE             = 0x0003f001 // error while saving config to file
 	ERROR_CONFIG_CHECK            = 0x0003f002 // error while checking config
 	ERROR_ICON_LOAD               = 0x0003f100 // error while loading icon
+	ERROR_VERSION_LOAD            = 0x0003f101 // error while loading version.json from server JAR
 	ERROR_PLAYER_NOT_IN_WHITELIST = 0x0003f200 // player is not in whitelist
 
 	// operative system package

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -108,3 +108,9 @@ type GameRawMessage struct {
 	Color string `json:"color"`
 	Bold  bool   `json:"bold"`
 }
+
+// struct for version.json of server JAR
+type VersionInfo struct {
+	Version  string `json:"release_target"`
+	Protocol int    `json:"protocol_version"`
+}


### PR DESCRIPTION
Changes the logic for the detection of the Minecraft and server protocol versions to include a check for the server JAR's [version.json](https://minecraft.fandom.com/wiki/Version.json) that is present in newer Minecraft versions. With these changes the new logic will be as follows:

1. If config values for protocol and version are present, use those
2. Otherwise, try to fetch the version information from the `version.json`
    - Log an error to inform the user that the versions have to be manually set if the file cannot be found or parsing it failed
3. Only update the config version information values in `getServInfo` for older versions of Minecraft before `version.json` was introduced (namely versions before snapshot 18w47b, checked by comparing the protocol version against 447)

The changes have mostly been tested except for the one in `getServInfo` but I hope to get around that on the weekend. Sorry that it's been a while since our conversation.