### PR TITLE
Change config loadDefault to use the working directory

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -119,7 +119,9 @@ func (c *Configuration) loadDefault() *errco.Error {
 	}
 
 	// read config file
-	configData, err := ioutil.ReadFile(filepath.Join(cwdPath, configFileName))
+	configFilePath := filepath.Join(cwdPath, configFileName)
+	errco.Logln(errco.LVL_1, "reading config file at: " + configFilePath)
+	configData, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
 		return errco.NewErr(errco.ERROR_CONFIG_LOAD, errco.LVL_1, "loadDefault", err.Error())
 	}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -112,14 +112,14 @@ func (c *Configuration) Save() *errco.Error {
 
 // loadDefault loads config file to config variable
 func (c *Configuration) loadDefault() *errco.Error {
-	// get msh executable path
-	mshPath, err := os.Executable()
+	// get working directory
+	cwdPath, err := os.Getwd()
 	if err != nil {
 		return errco.NewErr(errco.ERROR_CONFIG_LOAD, errco.LVL_1, "loadDefault", err.Error())
 	}
 
 	// read config file
-	configData, err := ioutil.ReadFile(filepath.Join(filepath.Dir(mshPath), configFileName))
+	configData, err := ioutil.ReadFile(filepath.Join(cwdPath, configFileName))
 	if err != nil {
 		return errco.NewErr(errco.ERROR_CONFIG_LOAD, errco.LVL_1, "loadDefault", err.Error())
 	}


### PR DESCRIPTION
On Linux distros with selinux executables must exist within a directory like `/usr/bin`, as such the executable directory can't work as a config path. This PR changes it to instead use the current working directory.