### PR TITLE
adjust list check for essentialsX Plugin users

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ _unknown clients are not allowed to start the server, but can join_
 
 Author: [gekigek99](https://github.com/gekigek99)  
 
-Contributors: [najtin](https://github.com/najtin), [f8ith](https://github.com/f8ith), [Br31zh](https://github.com/Br31zh), [someotherotherguy](https://github.com/someotherotherguy), [navidmafi](https://github.com/navidmafi), [cromefire](https://github.com/cromefire), [andreblanke](https://github.com/andreblanke), [KyleGospo](https://github.com/KyleGospo)  
+Contributors: [najtin](https://github.com/najtin), [f8ith](https://github.com/f8ith), [Br31zh](https://github.com/Br31zh), [someotherotherguy](https://github.com/someotherotherguy), [navidmafi](https://github.com/navidmafi), [cromefire](https://github.com/cromefire), [andreblanke](https://github.com/andreblanke), [KyleGospo](https://github.com/KyleGospo), [A-wels](https://github.com/A-wels)  
 
 Docker branch (outdated): [lubocode](https://github.com/lubocode/minecraft-server-hibernation)  
 

--- a/lib/servctrl/servctrl-utils.go
+++ b/lib/servctrl/servctrl-utils.go
@@ -66,7 +66,6 @@ func getPlayersByListCom() (int, *errco.MshLog) {
 		return 0, errco.NewLog(errco.TYPE_ERR, errco.LVL_3, errco.ERROR_SERVER_UNEXP_OUTPUT, "string does not contain \"INFO]:\"")
 	}
 
-	
 	// check test function for possible `list` outputs
 
 	// check if Essential plugin is used. If so, the output is different, because it mentions that Essentials is used in another message

--- a/lib/servctrl/servctrl-utils.go
+++ b/lib/servctrl/servctrl-utils.go
@@ -68,20 +68,15 @@ func getPlayersByListCom() (int, *errco.MshLog) {
 
 	// check test function for possible `list` outputs
 
-	// check if Essential plugin is used. If so, the output is different, because it mentions that Essentials is used in another message
-	var firstNumber string
-	if strings.Contains(output, "Essentials") {
-		firstNumber = regexp.MustCompile(`\d+`).FindString(strings.Split(output, "INFO]:")[2])
-	} else {
-		firstNumber = regexp.MustCompile(`\d+`).FindString(strings.Split(output, "INFO]:")[1])
+	playerCount := regexp.MustCompile(` \d+ `).FindString(output)
+	playerCount = strings.ReplaceAll(playerCount, " ", "")
+
+	// check if playerCount has been found
+	if playerCount == "" {
+		return 0, errco.NewLog(errco.TYPE_ERR, errco.LVL_3, errco.ERROR_SERVER_UNEXP_OUTPUT, "player count number not found in output of list command")
 	}
 
-	// check if firstNumber has been found
-	if firstNumber == "" {
-		return 0, errco.NewLog(errco.TYPE_ERR, errco.LVL_3, errco.ERROR_SERVER_UNEXP_OUTPUT, "firstNumber string is empty")
-	}
-
-	players, err := strconv.Atoi(firstNumber)
+	players, err := strconv.Atoi(playerCount)
 	if err != nil {
 		return 0, errco.NewLog(errco.TYPE_ERR, errco.LVL_3, errco.ERROR_CONVERSION, err.Error())
 	}

--- a/lib/servctrl/servctrl-utils.go
+++ b/lib/servctrl/servctrl-utils.go
@@ -66,8 +66,16 @@ func getPlayersByListCom() (int, *errco.MshLog) {
 		return 0, errco.NewLog(errco.TYPE_ERR, errco.LVL_3, errco.ERROR_SERVER_UNEXP_OUTPUT, "string does not contain \"INFO]:\"")
 	}
 
+	
 	// check test function for possible `list` outputs
-	firstNumber := regexp.MustCompile(`\d+`).FindString(strings.Split(output, "INFO]:")[1])
+
+	// check if Essential plugin is used. If so, the output is different, because it mentions that Essentials is used in another message
+	var firstNumber string
+	if strings.Contains(output, "Essentials") {
+		firstNumber = regexp.MustCompile(`\d+`).FindString(strings.Split(output, "INFO]:")[2])
+	} else {
+		firstNumber = regexp.MustCompile(`\d+`).FindString(strings.Split(output, "INFO]:")[1])
+	}
 
 	// check if firstNumber has been found
 	if firstNumber == "" {

--- a/lib/servctrl/servctrl-utils_test.go
+++ b/lib/servctrl/servctrl-utils_test.go
@@ -9,13 +9,21 @@ import (
 
 func Test_getPlayersByListCom(t *testing.T) {
 	output := []string{
+		// possible output after sending /list command
+
+		// positive cases [vanilla]
 		"[12:34:56] [Server thread/INFO]: There are 0 of a max of 20 players online:",
 		"[12:34:56] [Server INFO]: There are 0 out of maximum 20 players online.",
 
-		"[12:34:56] [Server ERROR]: There are 0 out of maximum 20 players online",
-		"[12:34:56] [Server INFO]: There are no numbers here",
+		// positive cases [plugins]
+		"[12:01:34 INFO]: Es sind 0 von maximal 15 Spielern online.", // [EssentialsX]
 
-		"[12:34:56 INFO]: [Essentials] CONSOLE issued server command: /list\n[12:34:56 INFO]: There are 0 of a max of 20 players online",
+		// negative cases [plugins]
+		"[12:34:56 INFO]: [Essentials] CONSOLE issued server command: /list", // [EssentialsX]
+
+		// negative cases [example]
+		"[12:34:56] [Server ERROR]: There are 0 out of maximum 20 players online",
+		"[12:34:56] [Server INFO]: Example where there are no numbers",
 	}
 	expected := 0
 
@@ -29,22 +37,16 @@ func Test_getPlayersByListCom(t *testing.T) {
 		}
 		// check test function for possible `list` outputs, also check for Essentials plugin
 
-		var firstNumber string
-		if strings.Contains(o, "Essentials") {
-			t.Logf("string contains \"Essentials\"")
-			firstNumber = regexp.MustCompile(`\d+`).FindString(strings.Split(o, "INFO]:")[2])
-		} else {
-			t.Logf("string does not contain \"Essentials\"")
-			firstNumber = regexp.MustCompile(`\d+`).FindString(strings.Split(o, "INFO]:")[1])
-		}
+		playerCount := regexp.MustCompile(` \d+ `).FindString(o)
+		playerCount = strings.ReplaceAll(playerCount, " ", "")
 
-		// check if firstNumber has been found
-		if firstNumber == "" {
-			t.Logf("firstNumber string is empty")
+		// check if playerCount has been found
+		if playerCount == "" {
+			t.Logf("playerCount string is empty")
 			continue
 		}
 
-		players, err := strconv.Atoi(firstNumber)
+		players, err := strconv.Atoi(playerCount)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/lib/servctrl/servctrl-utils_test.go
+++ b/lib/servctrl/servctrl-utils_test.go
@@ -14,6 +14,9 @@ func Test_getPlayersByListCom(t *testing.T) {
 
 		"[12:34:56] [Server ERROR]: There are 0 out of maximum 20 players online",
 		"[12:34:56] [Server INFO]: There are no numbers here",
+
+		"[12:34:56 INFO]: [Essentials] CONSOLE issued server command: /list\n[12:34:56 INFO]: There are 0 of a max of 20 players online",
+
 	}
 	expected := 0
 
@@ -25,9 +28,16 @@ func Test_getPlayersByListCom(t *testing.T) {
 			t.Logf("string does not contain \"INFO]:\"")
 			continue
 		}
-
-		// check test function for possible `list` outputs
-		firstNumber := regexp.MustCompile(`\d+`).FindString(strings.Split(o, "INFO]:")[1])
+		// check test function for possible `list` outputs, also check for Essentials plugin
+		
+		var firstNumber string
+		if strings.Contains(o, "Essentials") {
+			t.Logf("string contains \"Essentials\"")
+			firstNumber = regexp.MustCompile(`\d+`).FindString(strings.Split(o, "INFO]:")[2])
+		} else {
+			t.Logf("string does not contain \"Essentials\"")
+			firstNumber = regexp.MustCompile(`\d+`).FindString(strings.Split(o, "INFO]:")[1])
+		}
 
 		// check if firstNumber has been found
 		if firstNumber == "" {

--- a/lib/servctrl/servctrl-utils_test.go
+++ b/lib/servctrl/servctrl-utils_test.go
@@ -16,7 +16,6 @@ func Test_getPlayersByListCom(t *testing.T) {
 		"[12:34:56] [Server INFO]: There are no numbers here",
 
 		"[12:34:56 INFO]: [Essentials] CONSOLE issued server command: /list\n[12:34:56 INFO]: There are 0 of a max of 20 players online",
-
 	}
 	expected := 0
 
@@ -29,7 +28,7 @@ func Test_getPlayersByListCom(t *testing.T) {
 			continue
 		}
 		// check test function for possible `list` outputs, also check for Essentials plugin
-		
+
 		var firstNumber string
 		if strings.Contains(o, "Essentials") {
 			t.Logf("string contains \"Essentials\"")


### PR DESCRIPTION
This fixes #209 
EssentialsX adds a second line of output to the list command, which prevents the current approach from working.

I added a check to the function `getPlayersByListCom()` which looks out for the EssentialsX plugin