### PR TITLE
Correct path/filename for server.jar for Fabric

### DIFF
--- a/lib/config/config-utils.go
+++ b/lib/config/config-utils.go
@@ -204,7 +204,7 @@ func (c *Configuration) getVersionInfo(altServerName ...string) (string, int, *e
 	}
 
 	if c.Server.FileName != "server.jar" { //check if it matches the deafult name, if not
-		return c.getVersionInfo("server.jar") //fallback to default naming scheme
+		return c.getVersionInfo(filepath.Join("versions", c.Server.Version, "server-"+c.Server.Version+".jar")) //fallback to default naming scheme
 	}
 
 	return "", -1, errco.NewLog(errco.TYPE_ERR, errco.LVL_3, errco.ERROR_VERSION_LOAD, "minecraft server version and protocol could not be extracted from version.json")

--- a/lib/config/config-utils.go
+++ b/lib/config/config-utils.go
@@ -165,14 +165,13 @@ func (c *Configuration) loadIcon() *errco.MshLog {
 // In case of error "", -1, *errco.MshLog are returned.
 //
 // (checkout version.json info: https://minecraft.fandom.com/wiki/Version.json)
-func (c *Configuration) getVersionInfo() (string, int, *errco.MshLog) {
-	var serverFilename = c.Server.FileName
-
-	if strings.Contains(c.Server.FileName, "fabric-server-launch.jar") {
-		serverFilename = filepath.Join("versions", c.Server.Version, "server-"+c.Server.Version+".jar")
+func (c *Configuration) getVersionInfo(altServerName ...string) (string, int, *errco.MshLog) {
+	var serverFileName = c.Server.FileName
+	if len(altServerName) > 0 {
+		serverFileName = altServerName[0]
 	}
 
-	reader, err := zip.OpenReader(filepath.Join(c.Server.Folder, serverFilename))
+	reader, err := zip.OpenReader(filepath.Join(c.Server.Folder, serverFileName))
 	if err != nil {
 		return "", -1, errco.NewLog(errco.TYPE_WAR, errco.LVL_3, errco.ERROR_VERSION_LOAD, err.Error())
 	}
@@ -202,6 +201,10 @@ func (c *Configuration) getVersionInfo() (string, int, *errco.MshLog) {
 		}
 
 		return utility.FirstNon("", info.Version1, info.Version2), info.Protocol, nil
+	}
+
+	if c.Server.FileName != "server.jar" { //check if it matches the deafult name, if not
+		return c.getVersionInfo("server.jar") //fallback to default naming scheme
 	}
 
 	return "", -1, errco.NewLog(errco.TYPE_ERR, errco.LVL_3, errco.ERROR_VERSION_LOAD, "minecraft server version and protocol could not be extracted from version.json")

--- a/lib/config/config-utils.go
+++ b/lib/config/config-utils.go
@@ -166,7 +166,13 @@ func (c *Configuration) loadIcon() *errco.MshLog {
 //
 // (checkout version.json info: https://minecraft.fandom.com/wiki/Version.json)
 func (c *Configuration) getVersionInfo() (string, int, *errco.MshLog) {
-	reader, err := zip.OpenReader(filepath.Join(c.Server.Folder, c.Server.FileName))
+	var serverFilename = c.Server.FileName
+
+	if strings.Contains(c.Server.FileName, "fabric-server-launch.jar") {
+		serverFilename = filepath.Join("versions", c.Server.Version, "server-"+c.Server.Version+".jar")
+	}
+
+	reader, err := zip.OpenReader(filepath.Join(c.Server.Folder, serverFilename))
 	if err != nil {
 		return "", -1, errco.NewLog(errco.TYPE_WAR, errco.LVL_3, errco.ERROR_VERSION_LOAD, err.Error())
 	}


### PR DESCRIPTION
Fabric uses `fabric-server-launch.jar` to start the server. This file does not contain the version.json. Instead the `server.jar` containing this file is located under `versions/$VERSION/server-$VERSION.jar`. This PR corrects the path if Fabric is detected to read the correct file.