### PR TITLE
Add user-defined signal handling to freeze and warm up the Minecraft server

### DIFF
--- a/lib/progmgr/progmgr.go
+++ b/lib/progmgr/progmgr.go
@@ -26,6 +26,7 @@ var (
 	msh *program = &program{
 		startTime: time.Now(),
 		sigExit:   make(chan os.Signal, 1),
+		sigUser:   make(chan os.Signal, 1),
 		mgrActive: false,
 	}
 )
@@ -33,6 +34,7 @@ var (
 type program struct {
 	startTime time.Time      // msh program start time
 	sigExit   chan os.Signal // channel through which OS termination signals are notified
+	sigUser   chan os.Signal // channel through which User-defined signals are notified
 	mgrActive bool           // indicates if msh manager is running
 }
 
@@ -45,6 +47,8 @@ func MshMgr() {
 
 	// set msh.sigExit to relay termination signals
 	signal.Notify(msh.sigExit, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
+
+	SetupUserSignalHandling(msh)
 
 	msh.mgrActive = true
 

--- a/lib/progmgr/usersignal-posix.go
+++ b/lib/progmgr/usersignal-posix.go
@@ -1,0 +1,40 @@
+//go:build linux || darwin
+// +build linux darwin
+
+package progmgr
+
+import (
+	"msh/lib/errco"
+	"msh/lib/servctrl"
+	"os/signal"
+	"syscall"
+)
+
+// On POSIX, this function setups a goroutine that handles incoming SIGUSR1 and
+// SIGUSR2 signals and freeze or warms the server respectively
+func SetupUserSignalHandling(program *program) {
+	// set program.sigUser to relay user-defined signals
+	signal.Notify(program.sigUser, syscall.SIGUSR1, syscall.SIGUSR2)
+	go handleUserSignal()
+}
+
+// handleUserSignal is responsable for handling SIGUSR1 and SIGUSR2, to both freeze
+// and warm the minecraft server respectively
+// [goroutine]
+func handleUserSignal() {
+	for {
+		sig := <-msh.sigUser
+		errco.NewLogln(errco.TYPE_INF, errco.LVL_1, errco.ERROR_NIL, "received signal: %s", sig.String())
+
+		const (
+			SIGNAL_FREEZE = syscall.SIGUSR1
+			SIGNAL_WARM   = syscall.SIGUSR2
+		)
+
+		if sig == SIGNAL_WARM {
+			servctrl.WarmMS()
+		} else if sig == SIGNAL_FREEZE {
+			servctrl.FreezeMS(false)
+		}
+	}
+}

--- a/lib/progmgr/usersignal-windows.go
+++ b/lib/progmgr/usersignal-windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+// +build windows
+
+package progmgr
+
+// On Windows, we simply do nothing and never handle user-defined signals, since
+// SIGUSR does not exists.
+func SetupUserSignalHandling(program *program) {
+	return
+}


### PR DESCRIPTION
This implements feature request #270 to freeze and warm up the server using IPC with POSIX signals.
Note that this does nothing on Windows, since there isn't anything like SIGUSR1 or SIGUSR2.

I tested it in a medium-size Minecraft server and all seems to be working on Linux. (No testing done on MacOS but everything builds fine on all claimed supported OSes: Windows, Linux and MacOS).