### PR TITLE
Allow customizing connection error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ Hibernation and Starting server description
 "InfoStarting": "                   §fserver status:\n                    §6§lWARMING UP"
 ```
 
+Connection error message contents when client tries to join but the server is starting
+```yaml
+"MsgStarting": "Server start command issued. Please wait..."
+```
+
 Set to false if you don't want notifications (every 20 minutes)
 ```yaml
 "NotifyUpdate": true

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -201,6 +201,7 @@ func (c *Configuration) loadRuntime(confdef *Configuration) *errco.MshLog {
 	flag.IntVar(&c.Msh.SuspendRefresh, "suspendrefresh", c.Msh.SuspendRefresh, "Specify how often the suspended minecraft server process must be refreshed.")
 	flag.StringVar(&c.Msh.InfoHibernation, "infohibe", c.Msh.InfoHibernation, "Specify hibernation info.")
 	flag.StringVar(&c.Msh.InfoStarting, "infostar", c.Msh.InfoStarting, "Specify starting info.")
+	flag.StringVar(&c.Msh.MsgStarting, "msgstar", c.Msh.MsgStarting, "Specify server starting error message.")
 	flag.BoolVar(&c.Msh.NotifyUpdate, "notifyupd", c.Msh.NotifyUpdate, "Enables update notifications.")
 	flag.BoolVar(&c.Msh.NotifyMessage, "notifymes", c.Msh.NotifyMessage, "Enables message notifications.")
 	// c.Msh.Whitelist (type []string, not worth to make it a flag)

--- a/lib/conn/conn.go
+++ b/lib/conn/conn.go
@@ -139,7 +139,7 @@ func HandlerClientConn(clientConn net.Conn) {
 			}
 
 			// msh JOIN response (answer client with text in the loadscreen)
-			mes := buildMessage(reqType, "Server start command issued. Please wait... "+servstats.Stats.LoadProgress)
+			mes := buildMessage(reqType, config.ConfigRuntime.Msh.MsgStarting)
 			clientConn.Write(mes)
 			errco.NewLogln(errco.TYPE_BYT, errco.LVL_4, errco.ERROR_NIL, "%smsh --> client%s: %v", errco.COLOR_PURPLE, errco.COLOR_RESET, mes)
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -25,6 +25,7 @@ type Configuration struct {
 		SuspendRefresh                int      `json:"SuspendRefresh"` // specify if msh should refresh java server process suspension and every how many seconds
 		InfoHibernation               string   `json:"InfoHibernation"`
 		InfoStarting                  string   `json:"InfoStarting"`
+		MsgStarting                   string   `json:"MsgStarting"`
 		NotifyUpdate                  bool     `json:"NotifyUpdate"`
 		NotifyMessage                 bool     `json:"NotifyMessage"`
 		Whitelist                     []string `json:"Whitelist"`

--- a/msh-config.json
+++ b/msh-config.json
@@ -22,6 +22,7 @@
     "SuspendRefresh": -1,
     "InfoHibernation": "                   §fserver status:\n                   §b§lHIBERNATING",
     "InfoStarting": "                   §fserver status:\n                    §6§lWARMING UP",
+    "MsgStarting": "Server start command issued. Please wait...",
     "NotifyUpdate": true,
     "NotifyMessage": true,
     "Whitelist": [],


### PR DESCRIPTION
Hi!

Because a “connection error” message is displayed to the first player that tries to join when the server is stopped, I wanted to be able to customize it (useful for translating it to native language or providing more specific instructions, i.e. “try again in a minute”). So I made a few changes that allows everyone to set their own message via `msh-config.json`. This is my first time writing anything in Go, but I deployed these changes on my own server and it has been working great.

I thought maybe other users would appreciate this feature, so if you want, feel free to merge it. Thank you for this great project!